### PR TITLE
feat: add agents.md support for per-agent instruction extension

### DIFF
--- a/src/agent_framework/configs/agent_config.py
+++ b/src/agent_framework/configs/agent_config.py
@@ -197,6 +197,20 @@ class AgentConfig:
             # Convert dict to MemoryConfig Pydantic model
             memory_config = MemoryConfig(**config["memory"])
 
+        # Append agents.md from the same directory as the YAML if it exists.
+        # Each agent's agents.md is strictly scoped to its own directory — there
+        # is no inheritance or merging across agent directories, so files from
+        # different agents never interfere with each other.
+        # Set ``load_agents_md: false`` in the YAML to opt out explicitly.
+        instruction_template = config["instruction_template"]
+        if config.get("load_agents_md", True):
+            agents_md_path = os.path.join(os.path.dirname(file_path), "agents.md")
+            if os.path.exists(agents_md_path):
+                with open(agents_md_path, "r") as md_file:
+                    agents_md_content = md_file.read().strip()
+                if agents_md_content:
+                    instruction_template = f"{instruction_template}\n\n{agents_md_content}"
+
         return cls(
             llm_provider_name=LLMProviderName(config["llm_provider_name"]),
             llm_model=LLMModel(config["llm_model"]),
@@ -209,7 +223,7 @@ class AgentConfig:
             ),
             agent_name=config["agent_name"],
             description=config["description"],
-            instruction_template=config["instruction_template"],
+            instruction_template=instruction_template,
             tags=config.get("tags", []),
             tools=config.get("tools", []) or [],
             skills=config.get("skills", []) or [],

--- a/src/all_agents/skills_demo_agent/agents.md
+++ b/src/all_agents/skills_demo_agent/agents.md
@@ -1,0 +1,18 @@
+# Skills Demo Agent — Extended Guidelines
+
+## Behaviour Rules
+
+- Always use the `calculator` skill for any arithmetic — never compute in your head.
+- When the user asks to search the web, use `web_search` and explain the stub note if no results are returned.
+- For URL fetching, use `http_request` and present the response body clearly.
+- Use the `greeter` skill only when the user explicitly asks to greet someone.
+
+## Response Style
+
+- Keep answers concise. Show the raw skill result, then add a one-sentence interpretation.
+- If a skill returns an error, explain what went wrong and suggest how to fix it.
+
+## Constraints
+
+- Do not perform calculations without the calculator skill.
+- Do not make HTTP requests to internal/private IP ranges (10.x, 192.168.x, 127.x).

--- a/tests/unit/agent_framework/configs/test_agent_config.py
+++ b/tests/unit/agent_framework/configs/test_agent_config.py
@@ -1,4 +1,6 @@
 import pathlib
+import tempfile
+import os
 
 from src.agent_framework.configs.agent_config import AgentConfig
 
@@ -34,3 +36,113 @@ def test_from_yaml_loads_tools_list_if_present():
 
     assert isinstance(config.tools, list)
     assert any(tool.get("type") == "agent" for tool in config.tools)
+
+
+# ---------------------------------------------------------------------------
+# agents.md support
+# ---------------------------------------------------------------------------
+
+_MINIMAL_YAML = """\
+agent_name: test_agent
+tags: []
+llm_provider_name: openai
+llm_model: gpt-4o
+temperature: 0.4
+execution_engine: adk
+streaming_mode: none
+description: Test agent
+instruction_template: |
+  You are a test agent.
+"""
+
+
+def _write_yaml(directory: str, content: str = _MINIMAL_YAML) -> str:
+    yaml_path = os.path.join(directory, "main_agent.yaml")
+    with open(yaml_path, "w") as f:
+        f.write(content)
+    return yaml_path
+
+
+def test_agents_md_appended_to_instruction_template():
+    with tempfile.TemporaryDirectory() as tmp:
+        yaml_path = _write_yaml(tmp)
+        agents_md = os.path.join(tmp, "agents.md")
+        with open(agents_md, "w") as f:
+            f.write("# Extra Rules\n\nAlways be concise.")
+
+        config = AgentConfig.from_yaml(yaml_path)
+
+        assert "You are a test agent." in config.instruction_template
+        assert "# Extra Rules" in config.instruction_template
+        assert "Always be concise." in config.instruction_template
+
+
+def test_agents_md_appended_after_instruction_template():
+    with tempfile.TemporaryDirectory() as tmp:
+        yaml_path = _write_yaml(tmp)
+        with open(os.path.join(tmp, "agents.md"), "w") as f:
+            f.write("## Appended section")
+
+        config = AgentConfig.from_yaml(yaml_path)
+
+        idx_base = config.instruction_template.index("You are a test agent.")
+        idx_md = config.instruction_template.index("## Appended section")
+        assert idx_base < idx_md
+
+
+def test_no_agents_md_leaves_instruction_template_unchanged():
+    with tempfile.TemporaryDirectory() as tmp:
+        yaml_path = _write_yaml(tmp)
+
+        config = AgentConfig.from_yaml(yaml_path)
+
+        assert config.instruction_template.strip() == "You are a test agent."
+
+
+def test_empty_agents_md_leaves_instruction_template_unchanged():
+    with tempfile.TemporaryDirectory() as tmp:
+        yaml_path = _write_yaml(tmp)
+        with open(os.path.join(tmp, "agents.md"), "w") as f:
+            f.write("   \n  ")  # whitespace only
+
+        config = AgentConfig.from_yaml(yaml_path)
+
+        assert config.instruction_template.strip() == "You are a test agent."
+
+
+def test_load_agents_md_false_skips_file():
+    with tempfile.TemporaryDirectory() as tmp:
+        yaml_content = _MINIMAL_YAML + "load_agents_md: false\n"
+        yaml_path = _write_yaml(tmp, yaml_content)
+        with open(os.path.join(tmp, "agents.md"), "w") as f:
+            f.write("# Should not appear")
+
+        config = AgentConfig.from_yaml(yaml_path)
+
+        assert "Should not appear" not in config.instruction_template
+
+
+def test_each_agent_loads_only_its_own_agents_md():
+    """agents.md in one agent directory must not affect a different agent."""
+    with tempfile.TemporaryDirectory() as agent_a_dir:
+        with tempfile.TemporaryDirectory() as agent_b_dir:
+            yaml_a = _write_yaml(agent_a_dir)
+            with open(os.path.join(agent_a_dir, "agents.md"), "w") as f:
+                f.write("Agent A rules")
+
+            yaml_b = _write_yaml(agent_b_dir)
+            # agent_b has no agents.md
+
+            config_b = AgentConfig.from_yaml(yaml_b)
+
+            assert "Agent A rules" not in config_b.instruction_template
+
+
+def test_skills_demo_agent_agents_md_is_loaded():
+    project_root = _get_project_root()
+    yaml_path = project_root / "src" / "all_agents" / "skills_demo_agent" / "main_agent.yaml"
+
+    config = AgentConfig.from_yaml(str(yaml_path))
+
+    assert "agents.md" not in config.instruction_template  # file path not leaked
+    assert "calculator" in config.instruction_template.lower() or "Skills Demo Agent" in config.instruction_template


### PR DESCRIPTION
## Summary

- Each agent directory can now contain an `agents.md` file that is automatically appended to its `instruction_template` at config load time
- Strictly per-agent scoped — each agent reads only its own `agents.md`, no cross-agent inheritance possible
- `load_agents_md: false` in the YAML lets agents opt out explicitly
- Demo `agents.md` added to `skills_demo_agent` with behaviour rules, response style, and constraints

## How to use

Create `agents.md` alongside `main_agent.yaml` in any agent directory:

```
src/all_agents/my_agent/
├── main_agent.yaml
├── main_agent.py
└── agents.md          ← auto-loaded and appended to instruction_template
```

To opt out:
```yaml
# main_agent.yaml
load_agents_md: false
```

## No-clash guarantee

- `agents.md` lookup is resolved relative to each agent's YAML path — two agents in different directories can both have `agents.md` and they will never interfere with each other
- An empty or whitespace-only `agents.md` is treated as absent (no change to prompt)

## Stacked on

This PR is stacked on top of #28 (`feat/skills-add`). Base branch is `feat/skills-add`.

## Test plan

- [x] 9 unit tests in `tests/unit/agent_framework/configs/test_agent_config.py` — all passing
- [x] Full unit suite: 230 passed, 13 skipped, 0 failures
- [ ] Create `agents.md` in any agent dir, start server, verify the content appears in the system prompt (visible via debug logs or Studio)
- [ ] Set `load_agents_md: false`, confirm `agents.md` is ignored

🤖 Generated with [Claude Code](https://claude.com/claude-code)