### PR TITLE
ci: make a tag publish, and make the release gate catch what it missed

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -30,8 +30,9 @@ on:
   push:
     tags: ["v*"]
   # Lets you rehearse the whole thing against TestPyPI without cutting a tag. The inputs
-  # below only apply to a manual run — a tag publishes every package, to both indexes,
-  # with the stored token.
+  # below only apply to a manual run — a tag publishes every package, to both indexes.
+  # No secret is set, so both auth paths end at Trusted Publishing (OIDC); see
+  # docs/RELEASING.md.
   workflow_dispatch:
     inputs:
       packages:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -25,22 +25,13 @@ name: Release
 #   4. Run workflow -> packages: agentship-service,agentship-observability,agentship-sdk
 #
 # After that all six projects exist and every later release publishes all of them at once.
-# ---------------------------------------------------------------------------------------
-# PAUSED. Automatic triggers are commented out below; this runs only when you start it by
-# hand (Actions -> Release -> Run workflow).
-#
-# To re-enable: uncomment the `on:` block and delete this banner. Nothing else changed, so
-# it resumes exactly as it was.
-# ---------------------------------------------------------------------------------------
-# on:
-#   push:
-#     tags: ["v*"]
-  # Lets you rehearse the whole thing against TestPyPI without cutting a tag.
-#   workflow_dispatch:
-
-
-# Manual-only while paused:
 on:
+  # The only thing that publishes. Pushing to a branch never reaches an index; a tag does.
+  push:
+    tags: ["v*"]
+  # Lets you rehearse the whole thing against TestPyPI without cutting a tag. The inputs
+  # below only apply to a manual run — a tag publishes every package, to both indexes,
+  # with the stored token.
   workflow_dispatch:
     inputs:
       packages:
@@ -213,6 +204,17 @@ jobs:
       #
       # --extra-index-url, not --index-url: the third-party dependencies live on real
       # PyPI, and only our own packages are on TestPyPI.
+      # The version comes from the packages, not from the ref: a manual rehearsal runs on a
+      # branch, where GITHUB_REF_NAME is "main" and "==main" is not a version anyone can
+      # resolve. The build job has already proven a tag agrees with this same number.
+      - name: Resolve the version being verified
+        id: version
+        run: |
+          version=$(python -c "import sys; sys.path.insert(0, 'scripts'); \
+            import versions; print(versions.declared_version(versions.pyprojects()[0]))")
+          echo "version=$version" >> "$GITHUB_OUTPUT"
+          echo "verifying $version"
+
       - name: Install the published packages from TestPyPI
         run: |
           python -m pip install --upgrade pip
@@ -220,12 +222,16 @@ jobs:
             if pip install \
                  --index-url https://test.pypi.org/simple/ \
                  --extra-index-url https://pypi.org/simple/ \
-                 "agentship[starter]==${GITHUB_REF_NAME#v}"; then
-              break
+                 "agentship-sdk[starter]==${{ steps.version.outputs.version }}"; then
+              exit 0
             fi
             echo "index not ready yet, retrying in 20s ($attempt/5)"
             sleep 20
           done
+          # Falling out of the loop means five attempts failed. Say so and stop, rather
+          # than letting the smoke-test step below fail with a confusing "command not found".
+          echo "could not install from TestPyPI after 5 attempts" >&2
+          exit 1
 
       - name: Smoke-test what a user would actually get
         run: |
@@ -235,6 +241,30 @@ jobs:
           assert "site-packages" in agentship.__file__, agentship.__file__
           print("installed from TestPyPI:", agentship.__file__)
           EOF
+
+      # `--help` and an import prove the wheels unpack, not that the product works. 0.0.1
+      # passed both and still could not run an agent: observability defaulted to a provider
+      # the starter stack does not install, so the first command in the README failed. Run
+      # the quickstart itself — keyless, in a clean directory, with no provider key in the
+      # environment — so the next release cannot ship that class of bug again.
+      - name: Run the README quickstart, exactly as a new user would
+        env:
+          OPENAI_API_KEY: ""
+          ANTHROPIC_API_KEY: ""
+        run: |
+          mkdir -p "$RUNNER_TEMP/quickstart"
+          cd "$RUNNER_TEMP/quickstart"
+          cat > hello.yaml <<'EOF'
+          name: hello
+          engine: echo
+          prompt: A stand-in agent that needs no provider.
+          EOF
+          out=$(agentship run hello.yaml --input "hi there")
+          echo "$out"
+          case "$out" in
+            *"hi there"*) echo "quickstart works" ;;
+            *) echo "quickstart did not echo the input" >&2; exit 1 ;;
+          esac
 
   pypi:
     name: PyPI ${{ matrix.package }}

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -28,6 +28,10 @@ yet cut a tagged release; entries are grouped by phase until v0.1 ships (phases 
 - **Documented the release strategy**: ADR 0005 (lockstep versioning, tag-triggered releases from
   `main`, no release branches, `0.0.x` while pre-release) and a rewritten `RELEASING.md` covering
   branching, cadence, and hotfix-from-a-tag.
+- **Recorded the actual state of both indexes.** PyPI has all six projects and working trusted
+  publishers; **TestPyPI has none of the six**, and no `testpypi-*` environments or pending
+  publishers exist. A tag would therefore fail at the `testpypi` job before reaching PyPI —
+  correctly, but it means TestPyPI must be set up before the first tag.
 - **Note on `0.0.1`:** it is live on PyPI and cannot run an agent. PyPI versions are immutable, so
   it will be superseded by `0.0.2` and yanked, never replaced.
 

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -15,6 +15,22 @@ yet cut a tagged release; entries are grouped by phase until v0.1 ships (phases 
 
 ## [Unreleased]
 
+### Release engineering (2026-09-07)
+- **A tag now publishes.** `release.yml`'s tag trigger had been commented out, so `git push --tags`
+  did nothing. Re-enabled as `push: tags: ["v*"]` on the live `on:` block, keeping the
+  `packages`/`target`/`auth` inputs that the manual rehearsal path depends on.
+- **Fixed the install-back-out gate**, which could not have passed: it installed
+  `agentship[starter]` (the meta-package is `agentship-sdk`) pinned to `${GITHUB_REF_NAME#v}`
+  (the string `main` on a manual run). The version now comes from the packages.
+- **The gate now runs the README quickstart** — keyless, in a clean directory, with provider keys
+  emptied — before PyPI is touched. `--help` plus an import passed against `0.0.1`, which could
+  not run an agent at all; the check has to reproduce what a user does.
+- **Documented the release strategy**: ADR 0005 (lockstep versioning, tag-triggered releases from
+  `main`, no release branches, `0.0.x` while pre-release) and a rewritten `RELEASING.md` covering
+  branching, cadence, and hotfix-from-a-tag.
+- **Note on `0.0.1`:** it is live on PyPI and cannot run an agent. PyPI versions are immutable, so
+  it will be superseded by `0.0.2` and yanked, never replaced.
+
 ### Testing & verification tooling (2026-08-25)
 - Promoted the conformance capability catalogue into the shipped, vendor-free `agentship.conformance`
   module (importable from `agentship-core`, no longer test-only): `CAPABILITIES`, `Capability`,

--- a/docs/RELEASING.md
+++ b/docs/RELEASING.md
@@ -120,16 +120,20 @@ worked" into "a user can install this".
 
 ## Publishing credentials
 
-Publishing supports both, and the workflow picks by input:
+**There is no API token in this repository**, and none is needed. Publishing uses PyPI
+Trusted Publishing (OIDC): GitHub proves the workflow's identity and PyPI issues a
+short-lived credential. Verified — the repo has no secrets at repository, organisation or
+environment scope, and `0.0.1` reached PyPI anyway.
 
-| `auth` input | Credential | When |
+The `auth` input exists to *test* the two paths, not to choose a strategy:
+
+| `auth` input | `password` passed to the publish action | Result |
 |---|---|---|
-| `token` (default, and what a tag uses) | `PYPI_API_TOKEN` / `TEST_PYPI_API_TOKEN` repo secrets | today |
-| `trusted-publishing` | OIDC — no stored secret | once configured below |
+| `token` (default) | `secrets.PYPI_API_TOKEN` — unset, so empty | action falls back to OIDC |
+| `trusted-publishing` | explicitly empty | OIDC |
 
-Trusted Publishing is where this should land: GitHub proves the workflow's identity and PyPI
-issues a short-lived credential, so no long-lived token sits in the repository. Until every
-project is configured for it, releases go out on stored tokens.
+Both end at OIDC while no secret exists. Setting `PYPI_API_TOKEN` is what would switch the
+default to token auth; nothing does that today, and nothing should need to.
 
 Configure once per project at <https://pypi.org/manage/account/publishing/>. All six use
 the same owner/repo/workflow and differ only by **environment**:
@@ -179,12 +183,36 @@ again.
 
 ## State of the six names
 
-- [x] **Reserved on PyPI** (2026-09-06) — all six exist at `0.0.1`
-- [ ] Trusted Publishing configured for all six, on both indexes — publishing currently
-      uses stored tokens (see above); the switch is `auth: trusted-publishing`
-- [ ] Yank `0.0.1` — it is live and cannot run an agent. Yanking hides it from every
-      resolver (`pip install agentship-sdk` skips it) without freeing the number, which is
-      burned regardless. Done per-project on pypi.org → Manage → Releases → Yank.
+Checked 2026-09-07 against both indexes and the repo's GitHub settings.
+
+| | PyPI | TestPyPI |
+|---|---|---|
+| Projects exist | ✅ all six at `0.0.1` | ❌ all six 404 — names free, nothing published |
+| GitHub environments | ✅ `pypi-agentship-*` (six) | ❌ none |
+| Trusted publishers | ✅ working (`0.0.1` published with no secret) | ❌ not registered |
+
+**A tag today would fail at the `testpypi` job**, before PyPI is touched. That is the
+pipeline behaving correctly — `pypi` requires `testpypi` not to have failed — but it means
+TestPyPI has to be set up before the first tag, not during it.
+
+### Remaining before a tag can succeed
+
+- [ ] **Register pending publishers on TestPyPI** for all six, at
+      <https://test.pypi.org/manage/account/publishing/>. Same owner/repo/workflow as PyPI,
+      environment `testpypi-<package>`. TestPyPI enforces the same **three pending publishers
+      at a time** limit, so this goes in two waves exactly like the PyPI claim below.
+      GitHub creates the `testpypi-*` environments itself on first run; the publishers are
+      the part that must exist up front.
+- [ ] **Rehearse** — Actions → Release → Run workflow, `target: testpypi`. This publishes to
+      TestPyPI only and runs the install-back-out check. Do this before any tag.
+- [ ] **Yank `0.0.1` on PyPI** — it is live and cannot run an agent. Yanking hides it from
+      every resolver (`pip install agentship-sdk` skips it) without freeing the number, which
+      is burned regardless. Per-project: pypi.org → Manage → Releases → Yank.
+
+TestPyPI versions are immutable too, so a rehearsal burns the number it publishes. Rehearse
+with the version you intend to release and the tag will find it already there — harmless,
+since `skip-existing: true` covers it, but the install-back-out check is then verifying the
+rehearsal's upload rather than the tag's.
 
 **`0.0.1` is permanent and broken.** It shipped before the observability default was fixed,
 so `agentship run` failed on the README's own quickstart. It cannot be replaced — PyPI

--- a/docs/RELEASING.md
+++ b/docs/RELEASING.md
@@ -16,30 +16,87 @@ this was enforced, the meta-package depended on its siblings with no constraint 
 
 ```bash
 python scripts/versions.py --check       # CI gate; non-zero on any drift
-python scripts/versions.py --set 0.1.0   # bump all six and every pin at once
+python scripts/versions.py --set 0.0.2   # bump all six and every pin at once
 ```
 
 Never hand-edit a version. Six hand-edited strings is how a release ships with one missed.
 
-### What 0.x means
+`--check` verifies the six agree **with each other**, not that you bumped anything. Ordinary
+commits never touch a version, so it passes indefinitely while work continues.
+
+### Where we are: `0.0.x`
+
+**We are on `0.0.x` and staying there for now.** The phases that define v0.1 are still in
+flight, and `0.1.0` is a claim — "usable, still moving" — the tree cannot make yet. `0.0.x`
+says what is true: the packages exist, they are being tested in the open, and nothing is
+promised. The next release is `0.0.2`.
+
+### What 0.x will mean
 
 While the version starts with `0.`, **the API can break between minor versions**. `0.2.0`
-may break code written against `0.1.0`. Pin exactly (`agentship==0.1.0`) if that matters
+may break code written against `0.1.0`. Pin exactly (`agentship-sdk==0.1.0`) if that matters
 to you. From `1.0.0` we follow semantic versioning and breaking changes wait for a major.
 
 This is stated because "0.x means unstable" is a convention, not a rule a resolver knows.
 
+## Branching
+
+**Trunk-based. Releases are cut from `main`; there are no release branches.**
+
+```
+feature branch  ──►  PR  ──►  main  ──►  tag  ──►  published
+```
+
+`main` stays releasable at all times, so whatever is on it when you tag is what ships. That
+is the real control point: a fix reaches users because it was merged *and* a tag was cut
+after it — there is no per-fix switch. Merge to `main` only what you would be content to
+publish in the next release.
+
+A tag points at a commit permanently, so a released tree can always be reconstructed:
+
+```bash
+git checkout v0.0.2   # exactly what produced those wheels
+```
+
+**When we would add a release branch — and why we have not.** LangGraph keeps long-lived `0.4`
+and `0.6` branches to patch older lines while `main` moves on. That only matters once you
+support more than one line at a time. With a single supported line, a hotfix is:
+
+```bash
+git checkout -b hotfix/0.0.3 v0.0.2   # branch from the released TAG, not main
+git cherry-pick <the fix>             # take only that commit
+python scripts/versions.py --set 0.0.3
+git tag v0.0.3 && git push origin v0.0.3
+```
+
+Reach for that only when `main` has moved somewhere you cannot ship yet. Normally, tag `main`.
+
+## Cadence — when to cut a release
+
+A published version can never change, so any fix that reaches users needs a new number. That
+does **not** mean a release per fix. Batch them:
+
+- **Routine fixes and features** — let them accumulate on `main`, ship with the next release.
+- **The published build is unusable** — release immediately, even for one commit.
+
+`0.0.1` was the second kind: it could not run an agent at all. Most fixes are the first kind.
+Releasing on every commit burns numbers and produces an event — six uploads, a tag, a GitHub
+Release, a changelog entry — for changes nobody was waiting on.
+
 ## Cutting a release
 
 ```bash
-python scripts/versions.py --set 0.1.0
+python scripts/versions.py --set 0.0.2
 python scripts/versions.py --check
-pytest -q
+make test
 
-git commit -am "release: 0.1.0"
-git tag v0.1.0
+git commit -am "release: 0.0.2"
+git tag v0.0.2
 git push origin main --tags
 ```
+
+The version commit does nothing else — six `version =` lines and the pins between them — so
+the tag marks an unambiguous point in history.
 
 Pushing the tag runs `.github/workflows/release.yml`:
 
@@ -63,8 +120,16 @@ worked" into "a user can install this".
 
 ## Publishing credentials
 
-**There is no API token in this repository.** Publishing uses PyPI Trusted Publishing
-(OIDC): GitHub proves the workflow's identity and PyPI issues a short-lived credential.
+Publishing supports both, and the workflow picks by input:
+
+| `auth` input | Credential | When |
+|---|---|---|
+| `token` (default, and what a tag uses) | `PYPI_API_TOKEN` / `TEST_PYPI_API_TOKEN` repo secrets | today |
+| `trusted-publishing` | OIDC — no stored secret | once configured below |
+
+Trusted Publishing is where this should land: GitHub proves the workflow's identity and PyPI
+issues a short-lived credential, so no long-lived token sits in the repository. Until every
+project is configured for it, releases go out on stored tokens.
 
 Configure once per project at <https://pypi.org/manage/account/publishing/>. All six use
 the same owner/repo/workflow and differ only by **environment**:
@@ -112,9 +177,21 @@ A partial run skips the install-back-out check, since resolving `agentship-sdk` 
 six present. Once every project exists, leave `packages` on `all` and it never comes up
 again.
 
-## Before the first public release
+## State of the six names
 
-- [ ] Configure Trusted Publishing for all six projects, on both indexes
-- [ ] Reserve the six names on PyPI (a name taken later is a rename)
-- [ ] Rehearse with `workflow_dispatch` and install from TestPyPI by hand
-- [ ] Decide the first public version — `0.1.0` says "usable, still moving"
+- [x] **Reserved on PyPI** (2026-09-06) — all six exist at `0.0.1`
+- [ ] Trusted Publishing configured for all six, on both indexes — publishing currently
+      uses stored tokens (see above); the switch is `auth: trusted-publishing`
+- [ ] Yank `0.0.1` — it is live and cannot run an agent. Yanking hides it from every
+      resolver (`pip install agentship-sdk` skips it) without freeing the number, which is
+      burned regardless. Done per-project on pypi.org → Manage → Releases → Yank.
+
+**`0.0.1` is permanent and broken.** It shipped before the observability default was fixed,
+so `agentship run` failed on the README's own quickstart. It cannot be replaced — PyPI
+versions are immutable — only superseded by `0.0.2` and yanked.
+
+## When 0.1.0 happens
+
+Not yet, and not by accident. `0.1.0` is the first version that claims to be *usable*, so it
+waits until the v0.1 phase tail is closed — see `.spec-dev/STATUS.md` for what remains. Until
+then every release is `0.0.x`, whatever it contains.

--- a/docs/RELEASING.md
+++ b/docs/RELEASING.md
@@ -1,11 +1,10 @@
 # Releasing
 
-> **CI and the release pipeline are currently PAUSED.** Every workflow runs
-> manual-only (Actions → the workflow → Run workflow). To resume, uncomment the `on:`
-> block at the top of the workflow file and delete the PAUSED banner above it.
-
-AgentShip ships as **six distributions released together**: `agentship` (the meta-package)
+AgentShip ships as **six distributions released together**: `agentship-sdk` (the meta-package)
 plus `agentship-core`, `-langgraph`, `-service`, `-observability` and `-cli`.
+
+Pushing a tag matching `v*` is the only thing that publishes. Pushing to a branch runs the
+test gate and reaches no index, so `main` is never one accidental push away from a release.
 
 ## Versioning
 

--- a/docs/decisions/0005-lockstep-versioning-and-tag-triggered-releases.md
+++ b/docs/decisions/0005-lockstep-versioning-and-tag-triggered-releases.md
@@ -1,0 +1,74 @@
+# 0005 — One version for all six packages, released from a tag on `main`
+
+**Status:** accepted · **Scope:** release engineering (all packages); no phase owns this
+
+## Context
+
+AgentShip ships as six distributions — `agentship-core`, `-langgraph`, `-service`,
+`-observability`, `-cli` and the `agentship-sdk` meta-package. Six distributions means three
+questions that had to be answered before the first tag, and answering them by habit rather than
+on purpose is how a project ends up unable to say what version of itself is broken.
+
+**How are they versioned?** Independently, each moving on its own schedule, or in lockstep?
+LangGraph — the closest comparable, and a library we already consume — versions independently:
+its tags are `cli==0.4.4`, `sdk==0.4.4`, `checkpoint==2.1.1`, with 99 `cli` releases against 3
+for `checkpoint-duckdb`. That suits packages with genuinely independent lifecycles, and it buys a
+compatibility matrix: every combination of the six is something a user can install, so every
+combination is something someone has to reason about.
+
+**What triggers a publish?** A push to `main`, a manual button, or a tag.
+
+**Which branch do releases come from?** Trunk, or a long-lived release branch per line.
+
+The forcing event was concrete. The name-claiming upload of `0.0.1` shipped a build that could
+not run an agent at all — observability defaulted to a provider the starter stack does not
+install, so the first command in the README failed. PyPI versions are immutable, so that build is
+permanent, and the fix has to be a new number. A release process that lets that happen once will
+let it happen again.
+
+## Decision
+
+**One version across all six, every sibling pinned to exactly it.** `scripts/versions.py --set`
+moves all six and every pin at once; `--check` is a CI gate that fails on any drift. Six
+hand-edited strings is how a release ships with one missed.
+
+The six are only ever tested together — the conformance grid, the service contracts and the
+engine adapters are exercised as one tree — so a mixed set is a combination nobody has run.
+Independent versioning would mean publishing combinations we do not test. We take the cost
+(a package with no changes still gets a new number) to keep the guarantee (any two AgentShip
+packages a user has installed were tested against each other).
+
+**A tag matching `v*` is the only thing that publishes.** Pushing to a branch runs the test gate
+and reaches no index. The release is therefore a deliberate act with a name attached, never a
+side effect of merging, and `main` is never one accidental push away from PyPI.
+
+**Releases are cut from `main`. There are no release branches.** A feature branch merges to
+`main`, `main` stays releasable, and a tag points at the commit being released. We would only add
+a maintenance branch (LangGraph keeps `0.4` and `0.6` this way) to patch an old line *after* main
+had moved past it — which cannot arise while there is one supported line. Adding that machinery
+now would be guarding a situation we do not have.
+
+**While pre-release, the version is `0.0.x`.** Not `0.1.0`. The phases that define v0.1 are still
+in flight, and `0.1.0` is a claim — "usable, still moving" — that the tree cannot make yet.
+`0.0.x` says what is true: the packages exist, they are being tested in the open, and no
+stability of any kind is promised.
+
+## Consequence
+
+A user who has `agentship-core==0.0.4` knows every other AgentShip package they have is `0.0.4`,
+and that the set was tested together. Nobody has to reason about a matrix.
+
+The version on `main` means "the last thing published", not "what this tree is" — those diverge
+the moment work continues after a release, and that is expected rather than drift. `--check` only
+enforces the six agreeing *with each other*, so ordinary commits never touch a version.
+
+Because a published version can never change, any fix that reaches users needs a new number — but
+fixes are batched into a release, not released one at a time. The trigger to cut one is
+judgement: routine fixes wait, a build that cannot run does not.
+
+`verify-testpypi` installs the packages back out of a real index and runs the README quickstart
+keyless before PyPI is touched. That gate exists because `--help` plus an import passed against
+the broken `0.0.1`; the check has to reproduce what a user does, not what a build does.
+
+A future contributor must not: hand-edit a version, publish from a branch, or let the six drift
+apart to avoid a "pointless" bump on an unchanged package. The pointless bump is the feature.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -73,6 +73,8 @@ nav:
       - "0002 — Plain StateGraph supervisor": decisions/0002-plain-stategraph-supervisor.md
       - "0003 — LangGraph checkpointer substrate": decisions/0003-langgraph-checkpointer-as-the-durability-substrate.md
       - "0004 — Consume langchain-mcp-adapters": decisions/0004-consume-langchain-mcp-adapters.md
+      - "0005 — Lockstep versioning, tag-triggered releases": decisions/0005-lockstep-versioning-and-tag-triggered-releases.md
+  - Releasing: RELEASING.md
   - Changelog: CHANGELOG.md
 
 # Fail the build on a broken internal link or a page missing from nav, so a dead link is


### PR DESCRIPTION
Three defects in the release pipeline, all of which only bite on a real release. The
TestPyPI wave-1/wave-2 run just hit two of them.

## What the failing run proved

`verify-testpypi` installed `agentship[starter]`, but the meta-package is published as
`agentship-sdk`. This is not a harmless typo: **`agentship` is a real project on PyPI,
owned by someone else, at 0.1.3.** With `--extra-index-url https://pypi.org/simple/` the
resolver went looking for a stranger's package. The `==0.0.1` pin is the only reason it
failed instead of installing it.

The install then failed *silently* — the retry loop fell through after five attempts
without exiting non-zero — so the job continued to the smoke test and reported
`agentship: command not found` (exit 127), which points at the wrong step entirely.

## Changes

- **Tag trigger enabled** (`push: tags: ["v*"]`). It was commented out, so `git push --tags`
  published nothing. Added to the live `on:` block rather than by uncommenting the old one,
  which carried no inputs and would have dropped the `packages`/`target`/`auth` rehearsal path.
- **Correct distribution** — `agentship-sdk[starter]`, and the version now comes from the
  packages instead of `${GITHUB_REF_NAME#v}` (which is the string `main` on a manual run,
  making the gate unrunnable on a branch).
- **Retry loop fails loudly** after five attempts instead of falling through.
- **The gate now runs the README quickstart** — keyless, clean directory, provider keys
  emptied. `--help` plus an import passed against `0.0.1`, which could not run an agent at all.
- **Docs**: ADR 0005 (lockstep versioning, tag-triggered releases from `main`, no release
  branches, `0.0.x` while pre-release), `RELEASING.md` rewritten with branching, cadence and
  hotfix-from-a-tag, plus the verified state of both indexes.

## Expected behaviour on re-run

Against `0.0.1` the install will now succeed and **the quickstart step will fail** — because
`0.0.1` genuinely cannot run an agent. That is the gate working, not a regression. It goes
green from `0.0.2`, which contains f119676.

## Verification

`mkdocs build --strict` clean · 779 passed, 14 skipped, 3 xfailed · ruff clean · both
workflows parse; `release.yml` triggers on tags only, not branches.