### PR TITLE
ci: gate the starter install shape, and source release notes from the changelog

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -141,6 +141,59 @@ jobs:
           /tmp/clean/bin/agentship --help > /dev/null
           /tmp/clean/bin/agentship verify --help > /dev/null
 
+      # Everything above installs all six with EVERY extra, so observability is always
+      # present and the minimal install is never exercised. That is not a gap in coverage,
+      # it is the exact shape 0.0.1 shipped broken in: `provider` defaults to "otel", every
+      # agent is traced, and a stack without agentship-observability could not run ANY
+      # agent. `--help` and an import both passed; only running an agent caught it.
+      #
+      # So: install what `pip install "agentship-sdk[starter]"` actually gives a new user —
+      # no extras, no adapter — and run the README quickstart with the provider keys empty.
+      - name: Install the starter shape, as a new user gets it
+        run: |
+          python -m venv /tmp/starter
+          /tmp/starter/bin/pip install --upgrade pip
+          resolve() { ls "dist/$1-"*.whl | head -1; }
+          # Every sibling by explicit FILE PATH. --find-links is not enough: with the same
+          # version already on PyPI, pip will happily prefer the published wheel over the
+          # local one and silently test the wrong build. A path pins the exact file, while
+          # third-party dependencies still resolve normally from the index.
+          /tmp/starter/bin/pip install \
+            "$(resolve agentship_core)" \
+            "$(resolve agentship_langgraph)" \
+            "$(resolve agentship_service)" \
+            "$(resolve agentship_cli)" \
+            "$(resolve agentship_sdk)[starter]"
+          echo "installed:"; /tmp/starter/bin/pip list | grep -i agentship
+
+      - name: The starter shape must have NO observability adapter
+        run: |
+          if /tmp/starter/bin/pip show agentship-observability > /dev/null 2>&1; then
+            echo "agentship-observability is installed — this step no longer tests the" >&2
+            echo "shape it exists to test. Either [starter] gained the adapter (fine, drop" >&2
+            echo "this guard) or something pulled it in by accident (not fine)." >&2
+            exit 1
+          fi
+          echo "no adapter present, as intended"
+
+      - name: Run the README quickstart, keyless
+        env:
+          OPENAI_API_KEY: ""
+          ANTHROPIC_API_KEY: ""
+        run: |
+          mkdir -p "$RUNNER_TEMP/qs" && cd "$RUNNER_TEMP/qs"
+          cat > hello.yaml <<'EOF'
+          name: hello
+          engine: echo
+          prompt: A stand-in agent that needs no provider.
+          EOF
+          out=$(/tmp/starter/bin/agentship run hello.yaml --input "hi there")
+          echo "$out"
+          case "$out" in
+            *"hi there"*) echo "the starter shape can run an agent" ;;
+            *) echo "the starter shape cannot run an agent" >&2; exit 1 ;;
+          esac
+
       - name: Keep the distributions for inspection
         uses: actions/upload-artifact@v4
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -111,6 +111,12 @@ jobs:
           fi
           echo "tag and packages agree on $packaged"
 
+      # A release with no notes is one nobody wrote. Cheaper to fail here than to discover
+      # it after six uploads, when the version is burned and the page is already public.
+      - name: Check the changelog has a section for this version
+        if: startsWith(github.ref, 'refs/tags/v')
+        run: python scripts/changelog.py --check "${GITHUB_REF_NAME#v}"
+
       - name: Build every wheel and sdist
         run: |
           for pkg in agentship-core agentship-langgraph agentship-service \
@@ -324,10 +330,26 @@ jobs:
     permissions:
       contents: write
     steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.13"
+
       - uses: actions/download-artifact@v4
         with:
           name: distributions
           path: dist/
+
+      # The release page and the changelog must not be two accounts of the same release.
+      # `--generate-notes` alone writes the page from PR titles, which is a list of what was
+      # merged rather than a description of what changed — so the curated section wins, and
+      # the generated commit list is appended under it for anyone who wants the detail.
+      - name: Take the notes from the changelog
+        run: |
+          version="${GITHUB_REF_NAME#v}"
+          python scripts/changelog.py --section "$version" > "$RUNNER_TEMP/notes.md"
+          echo "notes for $version:"; cat "$RUNNER_TEMP/notes.md"
 
       - name: Publish the release with its distributions attached
         env:
@@ -336,4 +358,5 @@ jobs:
           gh release create "$GITHUB_REF_NAME" dist/* \
             --repo "$GITHUB_REPOSITORY" \
             --title "$GITHUB_REF_NAME" \
+            --notes-file "$RUNNER_TEMP/notes.md" \
             --generate-notes

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -5,8 +5,16 @@ All notable, user-facing changes to AgentShip, grouped by delivery phase. This f
 (when a non-obvious decision was made) all land. See `.spec-dev/operating-model.md` (DOCS gate) and
 `.spec-dev/STATUS.md` (the authoritative board).
 
-The format is loosely based on [Keep a Changelog](https://keepachangelog.com). This project has not
-yet cut a tagged release; entries are grouped by phase until v0.1 ships (phases 00–10).
+The format is loosely based on [Keep a Changelog](https://keepachangelog.com).
+
+**This file is the source of the GitHub release notes.** `scripts/changelog.py` extracts the
+`## [<version>]` section for a tag and the release workflow publishes it verbatim, so the release
+page and this file cannot drift. A tag whose version has no section here **fails the release
+before anything is published** — see [Releasing](RELEASING.md#release-notes).
+
+Work in progress accumulates under `## [Unreleased]`; cutting a release renames that heading to
+the version and dates it. Entries within a release are grouped by delivery phase, which is how
+they were written before the project cut tagged releases.
 
 <!-- BACKFILLED 2026-08-23 from code+tests during the status-reconciliation pass, not written at
      ship time. Headings were migrated to the post-renumber phase numbers as each phase's docs were
@@ -14,6 +22,18 @@ yet cut a tagged release; entries are grouped by phase until v0.1 ships (phases 
      DoD gate. See the phase-number note at the bottom. -->
 
 ## [Unreleased]
+
+## [0.0.2] — 2026-09-07
+
+**The first release that can actually run an agent.** `0.0.1` claimed the six names on PyPI and
+shipped a build whose quickstart failed on install; this replaces it. `0.0.1` has been yanked.
+
+### Fixed
+- **An agent runs without the observability adapter installed.** `provider` defaults to `otel`
+  and every agent is traced, so `pip install "agentship-sdk[starter]"` — which does not include
+  `agentship-observability` — could not run *any* agent, including the keyless echo example the
+  README opens with. A provider that was explicitly asked for still fails loudly; a defaulted one
+  now logs at debug and runs untraced.
 
 ### Release engineering (2026-09-07)
 - **A tag now publishes.** `release.yml`'s tag trigger had been commented out, so `git push --tags`
@@ -34,6 +54,16 @@ yet cut a tagged release; entries are grouped by phase until v0.1 ships (phases 
   correctly, but it means TestPyPI must be set up before the first tag.
 - **Note on `0.0.1`:** it is live on PyPI and cannot run an agent. PyPI versions are immutable, so
   it will be superseded by `0.0.2` and yanked, never replaced.
+
+## [0.0.1] — 2026-09-06 — YANKED
+
+The name-claiming upload: the six distributions were published to reserve their names on PyPI.
+The build itself was unusable — `agentship run` failed on the README's own quickstart — so this
+version has been **yanked** and is skipped by every resolver. Use `0.0.2` or later. The number
+cannot be reused; PyPI versions are immutable.
+
+Everything below shipped in this release. Entries are grouped by delivery phase rather than by
+version, because the project had not cut a tagged release when they were written.
 
 ### Testing & verification tooling (2026-08-25)
 - Promoted the conformance capability catalogue into the shipped, vendor-free `agentship.conformance`

--- a/docs/RELEASING.md
+++ b/docs/RELEASING.md
@@ -83,13 +83,46 @@ does **not** mean a release per fix. Batch them:
 Releasing on every commit burns numbers and produces an event — six uploads, a tag, a GitHub
 Release, a changelog entry — for changes nobody was waiting on.
 
+## Release notes
+
+**`docs/CHANGELOG.md` is the source; the GitHub release page is a copy of it.** Writing notes
+twice means they disagree, and the copy people actually read — the release page — is the one
+nobody remembers to update.
+
+```bash
+python scripts/changelog.py --check 0.0.2      # is there a section? (the release gate)
+python scripts/changelog.py --section 0.0.2    # print exactly what the page will show
+```
+
+A section is a `## [<version>]` heading and everything up to the next `##`:
+
+```markdown
+## [0.0.2] — 2026-09-07
+
+### Fixed
+- ...
+```
+
+The `build` job runs `--check` **before anything is published**, so a tag with no notes fails
+while it is still free to fix. `github-release` then publishes that section as the release body,
+with GitHub's generated commit list appended below it for anyone who wants the detail.
+
+Day to day: add entries under `## [Unreleased]` as you merge. Cutting a release is then just
+renaming that heading to the version and dating it.
+
 ## Cutting a release
 
 ```bash
+# 1. Notes first — the release gate checks for them, so write them before tagging.
+#    Rename `## [Unreleased]` in docs/CHANGELOG.md to `## [0.0.2] — <date>`.
+python scripts/changelog.py --check 0.0.2
+
+# 2. Version across all six, plus every sibling pin.
 python scripts/versions.py --set 0.0.2
 python scripts/versions.py --check
 make test
 
+# 3. The release commit does nothing else — six version lines and the pins between them.
 git commit -am "release: 0.0.2"
 git tag v0.0.2
 git push origin main --tags

--- a/scripts/changelog.py
+++ b/scripts/changelog.py
@@ -1,0 +1,98 @@
+"""Read one version's section out of ``docs/CHANGELOG.md``.
+
+The GitHub release for a tag should say the same thing the changelog says. Keeping them in
+two places means they disagree, and the one people read (the release page) is the one nobody
+remembers to update — so the release notes are EXTRACTED from the changelog rather than
+written again:
+
+    python scripts/changelog.py --section 0.0.2      # print that section's body
+    python scripts/changelog.py --check 0.0.2        # non-zero if it is missing or empty
+
+A section is a top-level ``## [<version>]`` heading and everything up to the next ``##``.
+The heading may carry a date or any other trailing text::
+
+    ## [0.0.2] — 2026-09-07
+
+``--check`` is what the release pipeline runs before publishing anything: a tag with no
+changelog section is a release nobody wrote notes for, and that is easier to fix before the
+upload than after.
+"""
+
+from __future__ import annotations
+
+import argparse
+import re
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parent.parent
+CHANGELOG = ROOT / "docs" / "CHANGELOG.md"
+
+
+def section_pattern(version: str) -> re.Pattern[str]:
+    """Return the regex matching ``## [<version>]`` and its body, up to the next heading.
+
+    The version is escaped, so a dotted version cannot act as a wildcard and match a
+    neighbouring release (``0.0.2`` must not find ``0x0y2``).
+    """
+    return re.compile(
+        r"^##\s*\[" + re.escape(version) + r"\][^\n]*\n(.*?)(?=^##\s|\Z)",
+        re.M | re.S,
+    )
+
+
+def extract(version: str, text: str | None = None) -> str | None:
+    """Return the body of ``version``'s changelog section, or ``None`` if there is none.
+
+    Surrounding blank lines are stripped. A heading that exists but has an empty body
+    returns the empty string, which :func:`check` treats as missing — a heading on its own
+    is not release notes.
+    """
+    if text is None:
+        text = CHANGELOG.read_text(encoding="utf-8")
+    found = section_pattern(version).search(text)
+    return found.group(1).strip() if found else None
+
+
+def check(version: str) -> int:
+    """Print a diagnosis and return an exit code: 0 when the section is usable."""
+    if not CHANGELOG.exists():
+        print(f"no changelog at {CHANGELOG}", file=sys.stderr)
+        return 1
+    body = extract(version)
+    if body is None:
+        print(
+            f"docs/CHANGELOG.md has no '## [{version}]' section.\n"
+            f"Add one — rename the [Unreleased] heading to [{version}] and date it — so the "
+            "GitHub release has notes somebody wrote.",
+            file=sys.stderr,
+        )
+        return 1
+    if not body:
+        print(f"'## [{version}]' exists but is empty; write the notes.", file=sys.stderr)
+        return 1
+    print(f"'## [{version}]' found, {len(body.splitlines())} lines")
+    return 0
+
+
+def main() -> int:
+    """Parse arguments and dispatch to --section or --check."""
+    parser = argparse.ArgumentParser(description=__doc__.splitlines()[0])
+    group = parser.add_mutually_exclusive_group(required=True)
+    group.add_argument("--section", metavar="VERSION", help="print the section body")
+    group.add_argument("--check", metavar="VERSION", help="fail if the section is missing")
+    args = parser.parse_args()
+
+    if args.check:
+        return check(args.check)
+
+    body = extract(args.section)
+    if not body:
+        print(f"no '## [{args.section}]' section in docs/CHANGELOG.md", file=sys.stderr)
+        return 1
+    print(body)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
The two commits that did not make it into #36 — its head was still `fc83c0e` when it merged.

## `ci: install the shape a new user gets, and run an agent in it`

The clean-environment job installs all six packages with **every extra**, so
`agentship-observability` is always present. That is why it passed on `0.0.1`: the bug was
that a stack *without* the adapter could not run any agent, and no job in CI ever built that
stack. `--help` and an import passed too — only running an agent found it.

The job now also installs `agentship-sdk[starter]` as a new user gets it and runs the README
quickstart with the provider keys empty. Siblings install by explicit **file path**, because
with the same version on PyPI pip prefers the published wheel and silently tests the wrong
build — which happened while verifying this by hand. A guard fails the job if the adapter
ever appears in that environment, since the step would then prove nothing.

Verified both directions: against wheels from this branch the quickstart prints
`echo: hi there` and the job passes; against the published `0.0.1` it fails with
`observability provider 'otel' is not installed`.

## `docs: make the changelog the source of the GitHub release notes`

`github-release` published with `--generate-notes` alone — a list of PR titles rather than a
description of what changed. `scripts/changelog.py` now extracts the `## [<version>]` section
and the workflow publishes it as the release body, with the generated commit list appended.

`build` runs `changelog.py --check` **before anything is published**, so a tag with no notes
fails while it is still free to fix.

Also drew the version boundary the changelog never had: it was written before any release, so
everything sat under `[Unreleased]` — but that work shipped **in `0.0.1`**. Marked as such,
leaving `0.0.2` to say the one thing that is new.

## Verification

779 passed, 14 skipped, 3 xfailed · ruff clean · `mkdocs build --strict` clean · both workflows
parse · `changelog.py --check` passes for 0.0.2 and 0.0.1 and exits 1 with an actionable
message for a version with no section.