### PR TITLE
fix(p06): a bad resume token is the caller's fault, and a 500 keeps its headers

### DIFF
--- a/packages/agentship-service/src/agentship_service/app.py
+++ b/packages/agentship-service/src/agentship_service/app.py
@@ -2,7 +2,7 @@
 
 The middleware are mounted in one documented order (outermost → innermost):
 
-    CORS → SecurityHeaders (+ trace id) → Auth (+ TenantScope) → router
+    CORS → SecurityHeaders (+ trace id) → ProblemFallback → Auth (+ TenantScope) → router
 
 so a request is CORS-checked, stamped, rate-limited (when enabled, P04 C5), and
 authenticated *before* any route runs, and a CORS preflight (``OPTIONS``) short-circuits at
@@ -21,7 +21,12 @@ from starlette.middleware.cors import CORSMiddleware
 
 from .build_info import build_info
 from .errors import install_error_handlers
-from .middleware import AuthMiddleware, RateLimitMiddleware, SecurityHeadersMiddleware
+from .middleware import (
+    AuthMiddleware,
+    ProblemFallbackMiddleware,
+    RateLimitMiddleware,
+    SecurityHeadersMiddleware,
+)
 from .registry import AgentRegistry
 from .routers import a2a_router, agents_router, live_router, studio_router, tasks_router
 from .routers.tasks import TaskStore
@@ -71,7 +76,8 @@ def create_app(
 
     # Mount inner → outer. add_middleware makes each call the new outermost layer, so the
     # last call (CORS) runs first on a request and the first call (Auth) runs last. The
-    # resulting request-path order is CORS → SecurityHeaders → RateLimit → Auth → router.
+    # resulting request-path order is
+    # CORS → SecurityHeaders → ProblemFallback → RateLimit → Auth → router.
     app.add_middleware(AuthMiddleware, auth=auth)
     app.add_middleware(
         RateLimitMiddleware,
@@ -79,6 +85,11 @@ def create_app(
         requests_per_second=requests_per_second,
         burst=rate_limit_burst,
     )
+    # Directly inside SecurityHeaders: an exception escaping ANY inner layer (auth, rate
+    # limit, a route) becomes problem+json here, so the response still travels back out
+    # through SecurityHeaders and is stamped like any other. Starlette's own
+    # ServerErrorMiddleware is outside everything the app mounts and cannot be.
+    app.add_middleware(ProblemFallbackMiddleware)
     app.add_middleware(SecurityHeadersMiddleware, hsts=hsts)
     if cors_origins:
         app.add_middleware(

--- a/packages/agentship-service/src/agentship_service/middleware/__init__.py
+++ b/packages/agentship-service/src/agentship_service/middleware/__init__.py
@@ -6,11 +6,13 @@ All middleware here is written as pure-ASGI wrappers rather than
 """
 
 from .auth import AuthMiddleware, get_caller, require_scope
+from .fallback import ProblemFallbackMiddleware
 from .headers import SecurityHeadersMiddleware
 from .ratelimit import RateLimitMiddleware
 
 __all__ = [
     "AuthMiddleware",
+    "ProblemFallbackMiddleware",
     "RateLimitMiddleware",
     "SecurityHeadersMiddleware",
     "get_caller",

--- a/packages/agentship-service/src/agentship_service/middleware/fallback.py
+++ b/packages/agentship-service/src/agentship_service/middleware/fallback.py
@@ -1,0 +1,81 @@
+"""Turn an unhandled exception into a problem+json response *inside* the middleware stack.
+
+Starlette's own backstop, ``ServerErrorMiddleware``, is the OUTERMOST layer — outside
+everything an app mounts. So a 500 it renders never passes back through
+:class:`~agentship_service.middleware.headers.SecurityHeadersMiddleware`: the security
+headers are never stamped, and the trace id has already been reset by that middleware's
+``finally`` before the handler runs. The result was a 500 that was measurably weaker than
+every other response the service sends — no ``x-content-type-options``, no
+``x-frame-options``, no ``referrer-policy``, and ``trace_id: null`` in the body, which is
+exactly the response someone needs a trace id for.
+
+Catching the exception one layer further IN fixes both at once: the response is an ordinary
+response travelling back out through the stack, so it is stamped like any other and the
+trace-id contextvar is still bound when the body is built.
+
+This does not replace the error handlers in :mod:`agentship_service.errors`. Everything
+they register is handled by ``ExceptionMiddleware`` and never reaches here; only genuinely
+unexpected exceptions do.
+"""
+
+from __future__ import annotations
+
+import logging
+
+from ..errors import PROBLEM_JSON, problem_dict
+
+logger = logging.getLogger("agentship.service")
+
+
+class ProblemFallbackMiddleware:
+    """Render any exception that escapes the routes as problem+json, in-stack."""
+
+    def __init__(self, app) -> None:
+        """Wrap ``app``; must be mounted INSIDE the security-headers middleware."""
+        self.app = app
+
+    async def __call__(self, scope, receive, send) -> None:
+        """Run the app, converting an escaped exception into a 500 problem document."""
+        if scope["type"] != "http":
+            await self.app(scope, receive, send)
+            return
+
+        started = False
+
+        async def watch(message: dict) -> None:
+            """Forward messages, remembering whether the response has begun."""
+            nonlocal started
+            if message["type"] == "http.response.start":
+                started = True
+            await send(message)
+
+        try:
+            await self.app(scope, receive, watch)
+        except Exception:
+            # Once the status line is on the wire there is no status left to change — a
+            # streaming response must signal failure in its own frames (the SSE route emits
+            # a terminal `error` frame). Re-raise so Starlette closes the connection.
+            if started:
+                raise
+            logger.exception("unhandled error serving %s", scope.get("path", "?"))
+            await _send_problem(send)
+
+
+async def _send_problem(send) -> None:
+    """Send a generic 500 problem document, never echoing the exception text."""
+    import json
+
+    body = json.dumps(
+        problem_dict(status=500, title="Internal Server Error", code="internal_error")
+    ).encode()
+    await send(
+        {
+            "type": "http.response.start",
+            "status": 500,
+            "headers": [
+                (b"content-type", PROBLEM_JSON.encode()),
+                (b"content-length", str(len(body)).encode()),
+            ],
+        }
+    )
+    await send({"type": "http.response.body", "body": body})

--- a/packages/agentship-service/src/agentship_service/models/v1.py
+++ b/packages/agentship-service/src/agentship_service/models/v1.py
@@ -14,6 +14,7 @@ from __future__ import annotations
 
 from typing import Any, Literal
 
+from agentship.engines.base import ResumeToken
 from pydantic import BaseModel, Field
 
 #: The kinds of event a stream can carry (SSE ``:stream`` / WS ``/live``):
@@ -77,7 +78,13 @@ class ResumeRequest(BaseModel):
 
     model_config = {"extra": "forbid"}
 
-    resume_token: dict = Field(..., description="The {engine, blob} token from a prior turn.")
+    # Typed, not `dict`: the token is validated at the API boundary, so a malformed one is a
+    # 422 problem document naming the bad field. As a bare `dict` it reached
+    # `ResumeToken.model_validate` inside the handler, where the ValidationError was nobody's
+    # registered error — a 500 that told the caller their own bad input was a server fault.
+    resume_token: ResumeToken = Field(
+        ..., description="The {engine, blob} token from a prior turn."
+    )
     session_id: str = Field(..., description="The paused run's session (its checkpoint thread).")
     resume_value: Any | None = Field(
         default=None, description='The human\'s decision, e.g. {"approved": true}.'

--- a/packages/agentship-service/src/agentship_service/routers/agents.py
+++ b/packages/agentship-service/src/agentship_service/routers/agents.py
@@ -15,7 +15,7 @@ import uuid
 from contextlib import contextmanager
 
 from agentship.context import Caller
-from agentship.engines.base import Result, ResumeToken
+from agentship.engines.base import Result
 from agentship.errors import CapabilityError
 from fastapi import APIRouter, Depends
 from sse_starlette.sse import EventSourceResponse
@@ -130,7 +130,7 @@ async def resume(
     agent = resolve_agent(agents, name)
     with log_turn("resume", name, caller, body.session_id):
         result = await agent.resume(
-            ResumeToken.model_validate(body.resume_token),
+            body.resume_token,
             resume_value=body.resume_value,
             caller=caller,
             session_id=body.session_id,

--- a/packages/agentship-service/tests/test_app.py
+++ b/packages/agentship-service/tests/test_app.py
@@ -13,6 +13,7 @@ from agentship.auth import ApiKeyAuthProvider, EnvApiKeyStore
 from agentship_service import create_app
 from agentship_service.middleware import (
     AuthMiddleware,
+    ProblemFallbackMiddleware,
     RateLimitMiddleware,
     SecurityHeadersMiddleware,
 )
@@ -100,28 +101,38 @@ def test_hsts_opt_in() -> None:
     assert "strict-transport-security" in resp.headers
 
 
-def test_middleware_order_is_cors_then_headers_then_ratelimit_then_auth() -> None:
-    """The stack is mounted outermost→innermost: CORS, SecurityHeaders, RateLimit, Auth.
+def test_middleware_order_is_cors_then_headers_then_fallback_then_ratelimit_then_auth() -> None:
+    """Mounted outermost→innermost: CORS, SecurityHeaders, ProblemFallback, RateLimit, Auth.
 
     Starlette lists ``user_middleware`` outermost-first (index 0 = added last), so the
-    documented request path CORS → SecurityHeaders → RateLimit → Auth → router is exactly
-    this order.
+    documented request path is exactly this order.
+
+    ProblemFallback sits directly INSIDE SecurityHeaders and outside everything else: it
+    must catch an exception from any inner layer, and its response must still travel back
+    out through SecurityHeaders to be stamped. Moving it inward (inside Auth) leaves an
+    auth-layer crash rendered by Starlette outside the stack — unstamped and untraceable.
     """
     app = create_app(auth=_auth(), cors_origins=["https://app.example"])
     classes = [m.cls for m in app.user_middleware]
     assert classes == [
         CORSMiddleware,
         SecurityHeadersMiddleware,
+        ProblemFallbackMiddleware,
         RateLimitMiddleware,
         AuthMiddleware,
     ]
 
 
 def test_cors_absent_when_no_origins() -> None:
-    """With no allow-list, CORS is not mounted — only SecurityHeaders, RateLimit, Auth."""
+    """With no allow-list, CORS is not mounted — the rest of the stack is unchanged."""
     app = create_app(auth=_auth())
     classes = [m.cls for m in app.user_middleware]
-    assert classes == [SecurityHeadersMiddleware, RateLimitMiddleware, AuthMiddleware]
+    assert classes == [
+        SecurityHeadersMiddleware,
+        ProblemFallbackMiddleware,
+        RateLimitMiddleware,
+        AuthMiddleware,
+    ]
 
 
 def test_options_preflight_short_circuits_before_auth() -> None:

--- a/packages/agentship-service/tests/test_error_model.py
+++ b/packages/agentship-service/tests/test_error_model.py
@@ -91,3 +91,39 @@ def test_unhandled_error_is_generic_500_without_leak() -> None:
     body = resp.json()
     assert body["code"] == "internal_error"
     assert "secret internal detail" not in resp.text
+
+
+def test_an_unexpected_500_is_as_hardened_as_every_other_response() -> None:
+    """A 500 must carry the same security headers and a trace id as a 200 does.
+
+    Starlette's own backstop, ``ServerErrorMiddleware``, is the OUTERMOST layer — outside
+    anything the app mounts. A 500 it rendered therefore never travelled back out through
+    the security-headers middleware, and that middleware's ``finally`` had already reset
+    the trace-id contextvar before the body was built. So the one response a caller is
+    most likely to report was the one with no headers and ``trace_id: null``.
+    """
+    from agentship_service import create_app
+    from agentship_service.registry import AgentRegistry
+
+    class _Boom:
+        """An auth provider whose authenticate blows up in an unforeseen way."""
+
+        async def authenticate(self, request):
+            """Fail with an error nothing has a handler for."""
+            raise RuntimeError("unforeseen")
+
+    client = TestClient(
+        create_app(auth=_Boom(), agents=AgentRegistry([])), raise_server_exceptions=False
+    )
+    resp = client.get("/v1/agents", headers={"x-api-key": "whatever"})
+
+    assert resp.status_code == 500
+    assert resp.headers["content-type"] == "application/problem+json"
+    assert resp.headers["x-content-type-options"] == "nosniff"
+    assert resp.headers["x-frame-options"] == "DENY"
+    assert resp.headers["referrer-policy"] == "no-referrer"
+    assert resp.headers["x-trace-id"], "a 500 is exactly when a caller needs the trace id"
+    body = resp.json()
+    assert body["code"] == "internal_error"
+    assert body["trace_id"] == resp.headers["x-trace-id"], "header and body must agree"
+    assert "unforeseen" not in resp.text, "still no leak"

--- a/packages/agentship-service/tests/test_v1_agents.py
+++ b/packages/agentship-service/tests/test_v1_agents.py
@@ -279,6 +279,18 @@ class _PausingEngine:
             interrupt={"action": "confirm_write", "tool": "send_email"},
         )
 
+    async def resume(self, compiled, token, ctx, *, resume_value=None):
+        """Finish the paused run, echoing the human's decision so the test can see it arrive.
+
+        Echoing ``resume_value`` is the point: it proves the decision travelled from the
+        request body through the router into the engine, rather than the endpoint merely
+        returning a plausible-looking 200.
+        """
+        from agentship.engines.base import Result
+
+        approved = (resume_value or {}).get("approved")
+        return Result(output=f"sent, approved={approved}", resume_token=None, interrupt=None)
+
 
 def _pausing_client() -> TestClient:
     """A client over an app serving one agent on the pausing engine."""
@@ -391,3 +403,64 @@ def test_an_agent_can_stream_even_when_its_yaml_does_not_say_streaming() -> None
 
     assert card["streaming"] is True, "an agent on a streaming engine can be streamed"
     assert card["capabilities"]["streaming"] is True
+
+
+# ---- :resume — the paths a pause is actually completed through ----------------------------------
+
+
+def test_resume_completes_a_paused_run() -> None:
+    """The happy path: a pause is resumed with the human's decision and the run finishes.
+
+    Everything else about `:resume` was tested through its refusals — wrong scope, a
+    non-durable engine, a body with no token. None of them proved the endpoint can do the
+    one thing it exists for, so a resume that returned the wrong shape, dropped
+    `resume_value`, or never reached the engine would have gone unnoticed.
+    """
+    client = _pausing_client()
+
+    paused = client.post(
+        "/v1/agents/drafter:invoke", json={"input": "email bob"}, headers={"x-api-key": "full"}
+    ).json()
+    assert paused["paused"] is True, "the run should be waiting on a human"
+
+    resumed = client.post(
+        "/v1/agents/drafter:resume",
+        json={
+            "resume_token": paused["resume_token"],
+            "session_id": paused["session_id"],
+            "resume_value": {"approved": True},
+        },
+        headers={"x-api-key": "full"},
+    )
+
+    assert resumed.status_code == 200
+    body = resumed.json()
+    assert body["output"] == "sent, approved=True", "the decision must reach the engine"
+    assert body["paused"] is False, "a completed resume is not still waiting"
+    assert body["resume_token"] is None, "a finished run hands back no token to resume again"
+    assert body["session_id"] == paused["session_id"], "a resume stays on the same thread"
+
+
+def test_a_malformed_resume_token_is_the_callers_fault() -> None:
+    """A token that is not a token is a 422, not a 500.
+
+    `resume_token` was typed `dict`, so anything JSON-shaped passed the boundary and was
+    validated inside the handler instead. The ValidationError that came back was nobody's
+    registered error, so the caller was told their own bad input was a server fault — and,
+    because Starlette renders that 500 outside the middleware stack, the response also
+    lost every security header and its trace id.
+    """
+    client = _pausing_client()
+
+    response = client.post(
+        "/v1/agents/drafter:resume",
+        json={"resume_token": {"nonsense": True}, "session_id": "s1"},
+        headers={"x-api-key": "full"},
+    )
+
+    assert response.status_code == 422, "a malformed token is a bad request"
+    body = response.json()
+    assert body["code"] == "invalid_request"
+    assert "resume_token" in (body["detail"] or ""), "say which field was wrong"
+    assert response.headers["x-content-type-options"] == "nosniff"
+    assert body["trace_id"], "the response a caller reports must carry a trace id"


### PR DESCRIPTION
Three of the four P06 defects on the board. Every one was **reproduced first**, then fixed,
then re-probed against a real uvicorn server over HTTP — not just `TestClient`.

## The issues, and the evidence

Identical probe script, real server, `main` vs this branch:

| | check | before (`main`) | after |
|---|---|---|---|
| **D1** | malformed `resume_token` status | ❌ `500` | ✅ `422` |
| | …names the bad field | ❌ `detail: null` | ✅ `body.resume_token.engine` |
| | …security headers | ❌ missing | ✅ present |
| | …`trace_id` | ❌ `null` | ✅ present |
| **D2** | unexpected 500 → `x-content-type-options` | ❌ missing | ✅ `nosniff` |
| | → `x-frame-options` | ❌ missing | ✅ `DENY` |
| | → `referrer-policy` | ❌ missing | ✅ `no-referrer` |
| | → `x-trace-id` | ❌ missing | ✅ present |
| | → no exception leak | ✅ | ✅ |
| **D3** | happy-path resume over HTTP | ✅ *(worked, untested)* | ✅ now tested |

**D3 is honest bookkeeping, not a behaviour fix.** Resume already worked on `main`; it had no
happy-path test, so a regression in shape, `resume_value` plumbing, or blob round-trip would
have gone unnoticed. The new test asserts the decision reaches the engine and the token blob
round-trips.

## Why D1's fix is at the boundary

`ResumeRequest.resume_token` was typed `dict`, so anything JSON-shaped passed validation and
was checked *inside* the handler by `ResumeToken.model_validate`. That `ValidationError` is
nobody's registered error → generic 500. Typing the field as `ResumeToken` validates it where
the rest of the request already is.

## Why D2 needed a new middleware, not a local patch

Starlette's `ServerErrorMiddleware` is the **outermost** layer — outside anything the app
mounts. A 500 it renders never travels back out through `SecurityHeadersMiddleware`, and that
middleware's `finally` has already reset the trace-id contextvar before the body is built. So
*every* unexpected 500 was weaker than every other response, on the one response a caller is
most likely to report.

`ProblemFallbackMiddleware` renders escaped exceptions one layer further in — directly inside
`SecurityHeaders`, outside auth and rate-limit — so the response is an ordinary response
travelling back out through the stack. **Mounting position is load-bearing:** inside `Auth`
(my first attempt) an auth-layer crash still escaped, which the new order test caught. It
re-raises if the response has already started, since a stream has no status left to change.

Verified it does not break streaming: SSE over a real server still arrives frame-by-frame
(`session` → `content` → `done`), unbuffered, headers stamped.

## D4 is deliberately not fixed — it is misfiled

`:stream` carries no pause signal, but the engine never emits one. `graph.astream()` is called
with callbacks and **no `configurable.thread_id`**, so a streamed run is not checkpointed at
all and cannot pause even in principle. The missing SSE frame is a symptom. That is P03/P08
durability work, not a router patch, and papering over it here would have hidden the real bug.

## Verification

782 passed (+3), 14 skipped, 3 xfailed · ruff clean · before/after probe on a real uvicorn
server · SSE re-checked end-to-end.