### PR TITLE
fix(p04): a Python MCP server runs under the interpreter that spawned the agent

### DIFF
--- a/packages/agentship-langgraph/src/agentship_langgraph/mcp.py
+++ b/packages/agentship-langgraph/src/agentship_langgraph/mcp.py
@@ -14,6 +14,7 @@ import asyncio
 import concurrent.futures
 import logging
 import os
+import sys
 from typing import TYPE_CHECKING, Any
 
 from agentship.errors import AgentShipError, CapabilityError
@@ -51,6 +52,31 @@ def mcp_version_ok() -> tuple[bool, str | None]:
     return (_MCP_MIN <= parts < _MCP_MAX_EXCLUSIVE, installed)
 
 
+#: Bare interpreter names in a ``command:``. An author writing these means "Python", not
+#: "whichever Python happens to be first on PATH in the shell that launched this".
+_BARE_PYTHON = frozenset({"python", "python3"})
+
+
+def _interpreter_for(command: str | None) -> str | None:
+    """Resolve a bare ``python``/``python3`` command to the interpreter already running.
+
+    A Python MCP server needs the ``mcp`` package to start. ``command: python3`` resolves
+    through PATH, so outside an activated virtualenv it finds the SYSTEM interpreter, which
+    does not have ``mcp``: the subprocess dies on import and the only symptom the agent sees
+    is ``Connection closed`` — pointing at the server rather than at the interpreter that
+    could not import its dependency. The same spec then passes or fails depending on shell
+    state, which makes it untrustworthy as a test.
+
+    Using :data:`sys.executable` runs the server under the same interpreter as the agent that
+    spawned it, which is by construction an environment where ``mcp`` exists. An absolute path
+    or any non-Python command is left exactly as written — that author named something
+    specific and meant it.
+    """
+    if command in _BARE_PYTHON:
+        return sys.executable
+    return command
+
+
 def to_connections(mcp: dict[str, McpServerSpec]) -> dict[str, dict[str, Any]]:
     """Translate the spec's ``mcp:`` block into a ``MultiServerMCPClient`` connections dict.
 
@@ -63,7 +89,7 @@ def to_connections(mcp: dict[str, McpServerSpec]) -> dict[str, dict[str, Any]]:
         if server.transport == "stdio":
             connections[name] = {
                 "transport": "stdio",
-                "command": server.command,
+                "command": _interpreter_for(server.command),
                 "args": list(server.args),
             }
         else:  # streamable_http

--- a/packages/agentship-langgraph/tests/test_mcp_interpreter.py
+++ b/packages/agentship-langgraph/tests/test_mcp_interpreter.py
@@ -1,0 +1,34 @@
+"""A Python MCP server must run under the interpreter that spawned the agent."""
+
+from __future__ import annotations
+
+import sys
+
+from agentship.spec import McpServerSpec
+from agentship_langgraph.mcp import to_connections
+
+
+def test_a_bare_python_command_uses_the_running_interpreter() -> None:
+    """``command: python3`` means this Python, not whatever PATH resolves to.
+
+    Outside an activated virtualenv, PATH's ``python3`` is the system interpreter, which does
+    not have ``mcp`` installed. The server subprocess then dies on import and the agent sees
+    only "Connection closed" — a message that points at the server rather than at the
+    interpreter that could not import its dependency. Worse, the same spec passes or fails
+    depending on shell state.
+    """
+    servers = {
+        "time": McpServerSpec(transport="stdio", command="python3", args=["server.py"]),
+    }
+    assert to_connections(servers)["time"]["command"] == sys.executable
+
+
+def test_an_explicit_command_is_left_exactly_as_written() -> None:
+    """An absolute path or a non-Python command is someone being specific on purpose."""
+    servers = {
+        "node": McpServerSpec(transport="stdio", command="npx", args=["-y", "some-server"]),
+        "pinned": McpServerSpec(transport="stdio", command="/usr/bin/python3.11", args=["s.py"]),
+    }
+    connections = to_connections(servers)
+    assert connections["node"]["command"] == "npx"
+    assert connections["pinned"]["command"] == "/usr/bin/python3.11"


### PR DESCRIPTION
Found by running the demo suite the way a stranger would — **venv not activated**.

```
tests/test_mcp.py  →  McpError: Connection closed
```

`command: python3` resolves through PATH, so outside an activated virtualenv it finds the
**system** interpreter, which has no `mcp`. The server subprocess dies on import, and the only
symptom the agent sees is "Connection closed" — pointing at the server rather than at the
interpreter that could not import its dependency.

The same spec passed with the venv on PATH and failed without it. A spec whose result depends
on shell state is not evidence of anything.

## Fix

Bare `python` / `python3` resolve to `sys.executable` — by construction the environment where
`mcp` exists, since it is the one running the agent that spawns the server. An absolute path or
a non-Python command (`npx`, `/usr/bin/python3.11`) is left exactly as written: that author
named something specific and meant it.

## Verification

The exact invocation that failed before now gives **50 passed, 12 skipped** in `agentship-demo`
with no venv on PATH and no provider keys. Framework suite: 813 passed, 14 skipped, 3 xfailed.
Lint clean.